### PR TITLE
Updated provizio::msg::radar_info to support DDMA and hyper-long range

### DIFF
--- a/provizio/msg/radar_info.idl
+++ b/provizio/msg/radar_info.idl
@@ -20,7 +20,8 @@ module provizio {
       short_range,
       medium_range,
       long_range,
-      ultra_long_range
+      ultra_long_range,
+      hyper_long_range
     };
 
     struct radar_info {

--- a/provizio_dds_idls_fastdds/provizio/msg/radar_info.h
+++ b/provizio_dds_idls_fastdds/provizio/msg/radar_info.h
@@ -75,7 +75,8 @@ namespace provizio {
             short_range,
             medium_range,
             long_range,
-            ultra_long_range
+            ultra_long_range,
+            hyper_long_range
         };
         /*!
          * @brief This class represents the structure radar_info defined by the user in the IDL file.


### PR DESCRIPTION
Non-backwards compatible change
Note that hyper-long range is only supported in DDMA or SPTDMA modes
Note also that SPTDMA mode is currently experimental (no `RadarProcessor` support yet)

Opening this PR for a discussion rather than a fully-formed merge proposal, although what is pushed is what I'm currently using as a template to refactor `radar_modes_app`.