### PR TITLE
Update TOPICS.md

### DIFF
--- a/TOPICS.md
+++ b/TOPICS.md
@@ -21,8 +21,9 @@ Radar point clouds (regular and super-resolution enhanced) can contain the follo
 | Radar-relative Y (left) position of the point in meters           | y                               | FLOAT32   | 1     | Always present                  |
 | Radar-relative Z (up) position of the point in meters             | z                               | FLOAT32   | 1     | Always present                  |
 | Radar-relative radial velocity of the point in meters per second  | radar_relative_radial_velocity  | FLOAT32   | 1     | Always present                  |
-| Ground-relative radial velocity of the point in meters per second | ground_relative_radial_velocity | FLOAT32   | 1     | **Can be missing or NaN value** |
 | Signal-to-noise ratio (dB)                                        | signal_to_noise_ratio           | FLOAT32   | 1     | Always present                  |
+| Ground-relative radial velocity of the point in meters per second | ground_relative_radial_velocity | FLOAT32   | 1     | **Can be missing or NaN value** |
+
 
 ## Entities: Fields
 


### PR DESCRIPTION
If we look precisely at make_point_cloud() function, the order of parameters is the following : relative_velocity, SnR and then ground_velocity.  Here, in the table, the order is relative_velocity, ground_velocity, SnR.

It confused me this afternoon, as I use this stable as Ground Truth of the fields position, so I propose to correct the order in the table.