### PR TITLE
APT-8659: TOPICS.md docs corrected

### DIFF
--- a/TOPICS.md
+++ b/TOPICS.md
@@ -19,9 +19,9 @@
 
 ## Services
 
-| Description | Topic Name | Request Data Type | Response Data Type | C++ Type Names / Pub-Sub Type Names | Python Type Names / Pub-Sub Type Names |
-| ----------- | ---------- | ----------------- | ------------------ | ----------------------------------- | -------------------------------------- |
-| Setting radar range | [provizio_set_radar_range](provizio/msg/radar_range.idl) | provizio/srv/set_radar_range_Request | provizio/srv/set_radar_range_Response | `provizio::srv::set_radar_range_Request` / `provizio::srv::set_radar_range_RequestPubSubType` & `provizio::srv::set_radar_range_Response` / `provizio::srv::set_radar_range_ResponsePubSubType` | `provizio_dds.set_radar_range_Request` / `provizio_dds.set_radar_range_RequestPubSubType` & `provizio_dds.set_radar_range_Response` / `provizio_dds.set_radar_range_ResponsePubSubType` |
+| Description | Service Name (same in provizio_dds and ROS 2) | Request DDS Topic Name | Response DDS Topic Name | Request Data Type | Response Data Type | C++ Type Names / Pub-Sub Type Names | Python Type Names / Pub-Sub Type Names |
+| ----------- | --------------------------------------------- | ---------------------- | ----------------------- | ------------------| ------------------ | ----------------------------------- | -------------------------------------- |
+| Setting radar range | [provizio_set_radar_range](provizio/msg/radar_range.idl) | rq/provizio_set_radar_rangeRequest | rr/provizio_set_radar_rangeReply | provizio/srv/set_radar_range_Request | provizio/srv/set_radar_range_Response | `provizio::srv::set_radar_range_Request` / `provizio::srv::set_radar_range_RequestPubSubType` & `provizio::srv::set_radar_range_Response` / `provizio::srv::set_radar_range_ResponsePubSubType` | `provizio_dds.set_radar_range_Request` / `provizio_dds.set_radar_range_RequestPubSubType` & `provizio_dds.set_radar_range_Response` / `provizio_dds.set_radar_range_ResponsePubSubType` |
 
 ## Radar Point Cloud: Fields
 


### PR DESCRIPTION
Small correction in TOPICS.md docs for the new request/response based radar range setting type interface

(service name + request topic name… + response topic name instead of a single topic name which was actually the service name)