### PR TITLE
APT-9227: radar_range now also defines an unknown range

### DIFF
--- a/TOPICS.md
+++ b/TOPICS.md
@@ -21,7 +21,7 @@
 
 | Description | Service Name (same in provizio_dds and ROS 2) | Request DDS Topic Name | Response DDS Topic Name | Request Data Type | Response Data Type | C++ Type Names / Pub-Sub Type Names | Python Type Names / Pub-Sub Type Names |
 | ----------- | --------------------------------------------- | ---------------------- | ----------------------- | ------------------| ------------------ | ----------------------------------- | -------------------------------------- |
-| Setting radar range | [provizio_set_radar_range](provizio/msg/radar_range.idl) | rq/provizio_set_radar_rangeRequest | rr/provizio_set_radar_rangeReply | provizio/srv/set_radar_range_Request | provizio/srv/set_radar_range_Response | `provizio::srv::set_radar_range_Request` / `provizio::srv::set_radar_range_RequestPubSubType` & `provizio::srv::set_radar_range_Response` / `provizio::srv::set_radar_range_ResponsePubSubType` | `provizio_dds.set_radar_range_Request` / `provizio_dds.set_radar_range_RequestPubSubType` & `provizio_dds.set_radar_range_Response` / `provizio_dds.set_radar_range_ResponsePubSubType` |
+| Setting radar range | [provizio_set_radar_range](provizio/srv/set_radar_range.idl) | rq/provizio_set_radar_rangeRequest | rr/provizio_set_radar_rangeReply | provizio/srv/set_radar_range_Request | provizio/srv/set_radar_range_Response | `provizio::srv::set_radar_range_Request` / `provizio::srv::set_radar_range_RequestPubSubType` & `provizio::srv::set_radar_range_Response` / `provizio::srv::set_radar_range_ResponsePubSubType` | `provizio_dds.set_radar_range_Request` / `provizio_dds.set_radar_range_RequestPubSubType` & `provizio_dds.set_radar_range_Response` / `provizio_dds.set_radar_range_ResponsePubSubType` |
 
 ## Radar Point Cloud: Fields
 

--- a/provizio/msg/radar_range.idl
+++ b/provizio/msg/radar_range.idl
@@ -16,6 +16,8 @@
 
 module provizio {
   module msg {
+    const unsigned long unknown_range = 65535; // 0xffff, same as in Provizio Core API
+    
     enum radar_range {
       short_range,
       medium_range,

--- a/provizio_dds_idls_fastdds/provizio/msg/radar_range.h
+++ b/provizio_dds_idls_fastdds/provizio/msg/radar_range.h
@@ -70,6 +70,7 @@ class CdrSizeCalculator;
 
 namespace provizio {
     namespace msg {
+        const uint32_t unknown_range = 65535;
         /*!
          * @brief This class represents the enumeration radar_range defined by the user in the IDL file.
          * @ingroup radar_range


### PR DESCRIPTION
Plus TOPICS.md link fixed.

Done as a constant as our version of Fast-DDS doesn't support enum keys with custom values